### PR TITLE
Switch to HTTPClient for Connection Reuse

### DIFF
--- a/box-view-ruby.gemspec
+++ b/box-view-ruby.gemspec
@@ -8,11 +8,11 @@ Gem::Specification.new do |s|
   s.summary = 'Ruby wrapper for the BoxView API'
   s.description = 'The Box View API lets you upload documents and then generate secure and customized viewing sessions for them.'
   s.authors = ['Brandon Goldman', 'Tim Frey']
-  s.email = %w(brandon.goldman@gmail.com timothy.frey@greenhouse.io)
+  s.email = %w(brandon.goldman@gmail.com timothy.frey@greenhouse.io tim.johnson@greenhouse.io)
   s.homepage = 'https://developers.box.com/view/'
   s.require_paths = %w{lib}
 
-  s.add_dependency 'rest-client'
+  s.add_dependency 'httpclient'
   s.add_dependency 'json'
   s.add_development_dependency 'rubocop'
 

--- a/lib/box_view/document.rb
+++ b/lib/box_view/document.rb
@@ -3,12 +3,12 @@ module BoxView
   # uploading, checking status, and deleting documents.
   class Document
     def self.delete(id)
-      BoxView._request("/documents/#{id}", :method => :delete, :json_response => false)
+      BoxView._request("documents/#{id}", :method => :delete, :json_response => false)
       true
     end
 
     def self.status(id)
-      BoxView._request("/documents/#{id}")
+      BoxView._request("documents/#{id}")
     end
 
     def self.upload(document_url, thumbnails: nil)
@@ -21,7 +21,7 @@ module BoxView
 
       params[:thumbnails] = thumbnails if thumbnails
 
-      response = BoxView._request('/documents', params, :method => :post)
+      response = BoxView._request('documents', params, :method => :post)
 
       response['id'] || BoxView::_error('missing_id', self.name, __method__, response)
     end

--- a/lib/box_view/download.rb
+++ b/lib/box_view/download.rb
@@ -8,14 +8,14 @@ module BoxView
     def self.document(id, extension: :pdf)
       raise "Invalid extension: #{extension}" unless VALID_EXTENSIONS.include?(extension)
 
-      BoxView._request("/documents/#{id}/content.#{extension.to_s}", :json_response => false)
+      BoxView._request("documents/#{id}/content.#{extension.to_s}", :json_response => false)
     end
 
     def self.thumbnail(id, width:, height:)
       return BoxView::_error('invalid_dimensions', name, __method__, nil) unless width && height
 
       params = {:width => width, :height => height}
-      BoxView._request("/documents/#{id}/thumbnail", params, :json_response => false,
+      BoxView._request("documents/#{id}/thumbnail", params, :json_response => false,
         :raise_unless_ready => true)
     end
   end

--- a/lib/box_view/session.rb
+++ b/lib/box_view/session.rb
@@ -4,7 +4,7 @@ module BoxView
   # document using a specific session-based URL.
   class Session
     def self.create(id, **params)
-      session = BoxView._request('/sessions', params.merge(:document_id => id), :method => :post,
+      session = BoxView._request('sessions', params.merge(:document_id => id), :method => :post,
         :raise_unless_ready => true)
       
       session['id']

--- a/lib/box_view/version.rb
+++ b/lib/box_view/version.rb
@@ -1,3 +1,3 @@
 module BoxView
-  VERSION = '1.0.3'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
We were spending more than 2/3rds of our request time negotiating SSL and setting up a connection. Using HTTPClient with the :keep_alive_timeout option, will reuse the same connection as long as it is used within 10 minutes.

We store the connection in the Thread.